### PR TITLE
Integrate `Link` and `href_`

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -29,7 +29,7 @@ server = return "example" :<|> return html where
     html = do
         p_ $ b_ "bar"
         p_ $ i_ "iik"
-        p_ $ a_ [safeHref_ stringLink] "string"
+        p_ $ a_ [absHref_ stringLink] "string"
 
 app :: Application
 app = serve api server

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -4,6 +4,7 @@
 module Main (main) where
 
 import Lucid
+import Lucid.Servant
 import Data.Maybe         (fromMaybe)
 import Network.Wai        (Application)
 import Servant
@@ -14,17 +15,21 @@ import Text.Read          (readMaybe)
 import qualified Network.Wai.Handler.Warp as Warp
 
 type API = "string" :> Get '[HTML] String
-    :<|> "html" :> Get '[HTML] (Html ())
+    :<|> "nested" :> "html" :> Get '[HTML] (Html ())
 
 api :: Proxy API
 api = Proxy
+
+stringLink :: Link
+stringLink = safeLink (Proxy :: Proxy API) (Proxy :: Proxy ("string" :> Get '[HTML] String))
 
 server :: Server API
 server = return "example" :<|> return html where
     html :: Html ()
     html = do
-        b_ "bar"
-        i_ "iik"
+        p_ $ b_ "bar"
+        p_ $ i_ "iik"
+        p_ $ a_ [safeHref_ stringLink] "string"
 
 app :: Application
 app = serve api server

--- a/servant-lucid.cabal
+++ b/servant-lucid.cabal
@@ -5,6 +5,8 @@ description:
   Servant support for lucid.
   .
   'HTML' content type which will use `ToHtml` class.
+  .
+  `safeHref_` uses a `Link` rather than `Text`.
 homepage:            http://haskell-servant.readthedocs.org/
 license:             BSD3
 license-file:        LICENSE
@@ -29,6 +31,7 @@ source-repository head
 
 library
   exposed-modules:     Servant.HTML.Lucid
+                       Lucid.Servant
   build-depends:       base       >=4.7     && <5
                      , http-media >=0.6.4   && <0.8
                      , lucid      >=2.9.8   && <2.10

--- a/servant-lucid.cabal
+++ b/servant-lucid.cabal
@@ -6,7 +6,7 @@ description:
   .
   'HTML' content type which will use `ToHtml` class.
   .
-  `safeHref_` uses a `Link` rather than `Text`.
+  Lucid.Servant uses `Link` rather than `Text` for safe 'href' attributes.
 homepage:            http://haskell-servant.readthedocs.org/
 license:             BSD3
 license-file:        LICENSE

--- a/src/Lucid/Servant.hs
+++ b/src/Lucid/Servant.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+-- | Some helper functions for creating values in
+-- [lucid](https://hackage.haskell.org/package/lucid) DSLs that work
+-- with [servant](https://hackage.haskell.org/package/servant).
 module Lucid.Servant
   ( absHref_
   , relHref_

--- a/src/Lucid/Servant.hs
+++ b/src/Lucid/Servant.hs
@@ -1,14 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Lucid.Servant
-  ( safeHref_
+  ( absHref_
+  , relHref_
   ) where
 
-import Servant.API (toUrlPiece)
-import Servant.Utils.Links (Link)
+import Data.Monoid ((<>))
 import Lucid (Attribute)
 import Lucid.Html5 (href_)
+import Servant.API (toUrlPiece)
+import Servant.Utils.Links (Link)
 
--- | Create an `href` attribute from a 'Link'.
+-- | Create an `href` attribute from a 'Link', with leading '/'.
 --
--- "servant" ensures that any 'Link' is valid.
-safeHref_ :: Link -> Attribute
-safeHref_ = href_ . toUrlPiece
+-- "servant" ensures that any 'Link' is valid within an API.
+-- This function ensures it is possible to navigate to that endpoint from
+-- a page which shares a root with that API.
+absHref_ :: Link -> Attribute
+absHref_ = href_ . ("/" <>) . toUrlPiece
+
+-- | Create an `href` attribute from a 'Link', as a relative link.
+--
+-- "servant" ensures that any 'Link' is valid within an API.
+-- Use this function if a relative link (no leading '/') is required.
+relHref_ :: Link -> Attribute
+relHref_ = href_ . toUrlPiece

--- a/src/Lucid/Servant.hs
+++ b/src/Lucid/Servant.hs
@@ -1,0 +1,14 @@
+module Lucid.Servant
+  ( safeHref_
+  ) where
+
+import Servant.API (toUrlPiece)
+import Servant.Utils.Links (Link)
+import Lucid (Attribute)
+import Lucid.Html5 (href_)
+
+-- | Create an `href` attribute from a 'Link'.
+--
+-- "servant" ensures that any 'Link' is valid.
+safeHref_ :: Link -> Attribute
+safeHref_ = href_ . toUrlPiece


### PR DESCRIPTION
This adds `absHref_` and `relHref_` functions for creating `href` attributes from `Link` values.

While they are simple to implement in downstream code, they are quite general and so may belong in this library, and there are a couple of points which tripped me up — not least that `Link` values serialized with `toUrlPiece` need a leading slash.

I would imagine `absHref_` is the more useful when serving one's own API. For linking to other APIs represented in servant, this PR has no solution (deliberately) and one should probably use `linkURI` directly (ensuring the slash is positioned correctly).

Edit: typo