### PR TITLE
Bump lucid upper bound to allow for 2.10

### DIFF
--- a/servant-lucid.cabal
+++ b/servant-lucid.cabal
@@ -31,7 +31,7 @@ library
                        Lucid.Servant
   build-depends:       base       >=4.9     && <5
                      , http-media >=0.6.4   && <0.9
-                     , lucid      >=2.9.8   && <2.10
+                     , lucid      >=2.9.8   && <2.11
                      , text       >=1.2.3.0 && <1.3
                      , servant    >=0.17    && <0.19
 


### PR DESCRIPTION
Fix https://github.com/haskell-servant/servant-lucid/issues/19