### PR TITLE
Allow `servant-0.19`

### DIFF
--- a/servant-lucid.cabal
+++ b/servant-lucid.cabal
@@ -33,7 +33,7 @@ library
                      , http-media >=0.6.4   && <0.9
                      , lucid      >=2.9.8   && <2.12
                      , text       >=1.2.3.0 && <1.3
-                     , servant    >=0.17    && <0.19
+                     , servant    >=0.17    && <0.20
 
   if !impl(ghc >= 8.0)
     build-depends:     semigroups >=0.18.4  && <0.20
@@ -52,7 +52,7 @@ test-suite example
       base
     , lucid
     , servant-lucid
-    , servant-server >=0.14     && <0.19
+    , servant-server >=0.14     && <0.20
     , wai            >=3.0.3.0  && <3.3
     , warp           >=3.0.13.1 && <3.4
   default-language: Haskell2010


### PR DESCRIPTION
Confirmed to build with `allow-newer`.