### PR TITLE
Allow text-2.1, warp-3.4

### DIFF
--- a/servant-lucid.cabal
+++ b/servant-lucid.cabal
@@ -32,7 +32,7 @@ library
   build-depends:       base       >=4.9     && <5
                      , http-media >=0.6.4   && <0.9
                      , lucid      >=2.9.8   && <2.12
-                     , text       >=1.2.3.0 && <1.3 || >= 2 && < 2.1
+                     , text       >=1.2.3.0 && <1.3 || >= 2 && < 2.2
                      , servant    >=0.17    && <0.21
 
   if !impl(ghc >= 8.0)
@@ -54,5 +54,5 @@ test-suite example
     , servant-lucid
     , servant-server >=0.14     && <0.21
     , wai            >=3.0.3.0  && <3.3
-    , warp           >=3.0.13.1 && <3.4
+    , warp           >=3.0.13.1 && <3.5
   default-language: Haskell2010


### PR DESCRIPTION
Tested using

    cabal test --enable-tests -c 'text>=2.1' -c 'warp>=3.4'
